### PR TITLE
Make user conversation more friendly on command line

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
     types: [opened, reopened]
 
 jobs:
-  goreleaser:
+  build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ on:
     types: [opened, reopened]
 
 jobs:
-  go-fmt:
+  lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -22,7 +22,5 @@ jobs:
       with:
         path: /home/runner/go/pkg/mod
         key: go-mod
-    - name: Reformat code base
-      run: make fmt
-    - name: Stop if reformatted
-      run: git diff --exit-code
+    - name: Run linters
+      run: make lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
     types: [opened, reopened]
 
 jobs:
-  tests:
+  test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -23,4 +23,4 @@ jobs:
         path: /home/runner/go/pkg/mod
         key: go-mod
     - name: Run test suite
-      run: make tests
+      run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+---
+name: Test
+
+on:
+  push:
+    branches:
+    - "*"
+    tags-ignore:
+    - "*"
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-go@v2-beta
+      with:
+        go-version: '^1.14.1'
+    - uses: actions/cache@v1
+      with:
+        path: /home/runner/go/pkg/mod
+        key: go-mod
+    - name: Run test suite
+      run: make tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-/.idea
-/.vscode
+/.idea/
+/.vscode/
+/dist/
 /seiso

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,10 +1,5 @@
 # Make sure to check the documentation at http://goreleaser.com
 
-before:
-  hooks:
-  - go vet ./...
-  - go test --cover ./...
-
 builds:
 - env:
   - CGO_ENABLED=0 # this is needed otherwise the Docker image build is faulty

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,22 @@
 .PHONY: all build clean dist fmt tests
 
-all: clean fmt tests build
+all: clean lint tests build
 
 fmt:
 	@echo 'Reformat Go code ...'
 	go fmt ./...
 
-tests:
+vet:
+	@echo 'Examine Go code ...'
+	go vet ./...
+
+lint: fmt vet
+	@echo 'Check for uncommitted changes ...'
+	git diff --exit-code
+
+test:
 	@echo 'Run all tests ...'
-	go test ./...
+	go test --cover ./...
 
 build:
 	@echo 'Build seiso binary ...'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build clean fmt tests
+.PHONY: all build clean dist fmt tests
 
 all: clean fmt tests build
 
@@ -14,6 +14,10 @@ build:
 	@echo 'Build seiso binary ...'
 	go build
 
+dist:
+	@echo 'Build all distributions ...'
+	goreleaser release --snapshot --rm-dist --skip-sign
+
 clean:
 	@echo 'Clean up build artifacts ...'
-	rm -f seiso
+	rm -rf seiso dist/

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all: clean fmt tests build
 
 fmt:
 	@echo 'Reformat Go code ...'
-	find . -type f -name '*.go' -exec go fmt {} \;
+	go fmt ./...
 
 tests:
 	@echo 'Run all tests ...'

--- a/README.md
+++ b/README.md
@@ -66,24 +66,21 @@ The ImageStream "application" is invalid: []: Internal error: ImageStream.image.
 1. It can be used more aggressively by deleting dangling image tags, "orphans",
    that happen to exist when the Git history is altered (e.g. by force-pushing).
 
-1. It can identify `ConfigMap` resources by its `config` label that are sufficiently
-   old to be deleted.
+1. It can identify `ConfigMap` resources by labels that are sufficiently old to be deleted.
 
-1. It can identify `Secret` resources by its `secret` label that are sufficiently
-   old to be deleted.
+1. It can identify `Secret` resources by labels that are sufficiently old to be deleted.
 
 *Seiso* is opinionated, e.g. with respect to naming conventions of image tags,
 either by relying on a long Git SHA-1 value (`namespace/app:a3d0df2c5060b87650df6a94a0a9600510303003`)
 or a Git tag following semantic versioning (`namespace/app:v1.2.3`).
 
-The cleanup **runs in dry-mode by default**. Only when the `--force` flag is specified,
-it will actually delete the identified resources. This should prevent accidental
-deletions during verifications or test runs.
+The cleanup **runs in dry-mode by default**. Only when the `--delete` flag
+is specified, it will actually delete the identified resources. This should
+prevent accidental deletions during verifications or test runs.
 
 ## Caveats and known issues
 
-* Currently only OpenShift image registries are supported. In future, more
-  resource types are planned to be supported for cleanup.
+* Currently, only OpenShift image registries are supported.
 
 * **Please watch out for shallow clones**, as the Git history might be missing,
   it would in some cases also undesirably delete image tags.
@@ -214,7 +211,7 @@ oc -n "$OPENSHIFT_PROJECT" plugin cleanup "$APP_NAME" -p "$PWD" -f=y
 ```
 becomes:
 ```console
-seiso images history "$OPENSHIFT_PROJECT/$APP_NAME" --force
+seiso images history "$OPENSHIFT_PROJECT/$APP_NAME" --delete
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -222,6 +222,10 @@ becomes:
 ```console
 seiso -n "$OPENSHIFT_PROJECT" image history "$APP_NAME" --delete
 ```
+We suggest cleaning up orphan image tags in addition, e.g.
+```console
+seiso -n "$OPENSHIFT_PROJECT" image orphans "$APP_NAME" --older-than 1w --delete
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -219,26 +219,43 @@ seiso images history "$OPENSHIFT_PROJECT/$APP_NAME" --force
 
 ## Development
 
-### Requirements
+Requirements:
 
 * go 1.13
 * goreleaser
 * Docker
 
-### Build
+Run code during development:
+```console
+go run main.go
+```
 
-```
-goreleaser release --snapshot --rm-dist --skip-sign
+Reformat all Go code:
+```console
+make fmt
 ```
 
-### Run
+Run test suite:
+```console
+make tests
 ```
-./dist/seiso_linux_amd64/seiso --help
-# or
+
+Build seiso binary:
+```console
+make clean build
+```
+
+Build binaries for all target distributions:
+```console
+make clean dist
+```
+
+Run seiso using its container image:
+```
 docker run --rm -it appuio/seiso:<tag>
 ```
 
-## Release
+### Release
 
 Push a git tag with the scheme `vX.Y.Z` (semver).
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ make fmt
 
 Run test suite:
 ```console
-make tests
+make test
 ```
 
 Build seiso binary:

--- a/README.md
+++ b/README.md
@@ -110,9 +110,13 @@ In all cases, it is assumed that the Git repository is already checked out in th
 Let's assume target branch is `a`:
 
 ```console
+seiso images history -n namespace app --keep 2
+```
+or, alternatively
+```console
 seiso images history namespace/app --keep 2
 ```
-Only the image tag `a1` will be deleted (only current branch is compared).
+Only the image tag `a1` would be deleted (only current branch is compared).
 
 ### Example: Keep no image tags
 
@@ -124,16 +128,20 @@ This would delete `a1` and `a2`, but *not* `a5`, as this image is being actively
 ### Example: Delete orphaned images
 
 ```console
+seiso images orphans -n namespace app --older-than 7d
+```
+or, alternatively
+```console
 seiso images orphans namespace/app --older-than 7d
 ```
-This will delete `a1`, `a2`, `b3` and `b4`, if we assume that `a5` is being actively used, and `c6` is younger than 7d
-(image tag push date, not commit date).
+This would delete `a1`, `a2`, `b3` and `b4`, if we assume that `a5` is being actively used,
+and `c6` is younger than 7d (image tag push date, not commit date).
 
-That means it will also look in other branches too. It also deletes amended/force-pushed commits, which do not show up
-in the history anymore, but would still be available in the registry.
+That means it will also look in other branches too. It also deletes amended/force-pushed commits,
+which do not show up in the history anymore, but would still be available in the registry.
 
-This is very useful in cases where the images from feature branches are being pushed to a `dev` namespace, but need to
-be cleaned up after some time. In the `production` namespace, we can apply different cleanup rules.
+This is very useful in cases where the images from feature branches are being pushed to a `dev` namespace,
+but need to be cleaned up after some time. In the `production` namespace, we can apply different cleanup rules.
 
 ### Example: Delete versioned image tags
 
@@ -191,14 +199,15 @@ Secrets
 ### Example: Delete unused ConfigMaps
 
 ```console
-seiso configmaps namespace -l app=example --keep 1 --older-than=1d
+seiso configmaps -n mynamespace -l app=example --keep 1 --older-than=1d
 ```
-This would delete unused ConfigMaps older than 5 hours, from the second element (sorted in descending order) and that have label `app=example`, more precisely `C4`.
+This would delete unused ConfigMaps older than 5 hours, from the second element (sorted in descending order)
+and that have label `app=example`, more precisely `C4`.
 
 ### Example: Delete unused Secrets
 
 ```console
-seiso secrets namespace -l app=example -l config=default --keep 0 --older-than=2w
+seiso secrets -n mynamespace -l app=example -l config=default --keep 0 --older-than=2w
 ```
 This would delete secrets older than 2 weeks with labels `app=example` and `config=default`, more precisely `S1 and S2`.
 
@@ -211,7 +220,7 @@ oc -n "$OPENSHIFT_PROJECT" plugin cleanup "$APP_NAME" -p "$PWD" -f=y
 ```
 becomes:
 ```console
-seiso images history "$OPENSHIFT_PROJECT/$APP_NAME" --delete
+seiso -n "$OPENSHIFT_PROJECT" image history "$APP_NAME" --delete
 ```
 
 ## Development

--- a/cfg/types.go
+++ b/cfg/types.go
@@ -13,7 +13,7 @@ type (
 		Orphan   OrphanConfig   `mapstructure:",squash"`
 		Resource ResourceConfig `mapstructure:",squash"`
 		Log      LogConfig
-		Force    bool
+		Delete   bool
 	}
 	// GitConfig configures git repository
 	GitConfig struct {
@@ -64,7 +64,7 @@ func NewDefaultConfig() *Configuration {
 			Labels:    []string{},
 			OlderThan: "2mo",
 		},
-		Force: false,
+		Delete: false,
 		Log: LogConfig{
 			LogLevel: "info",
 			Batch:    false,

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -98,11 +98,11 @@ func addCommonFlagsForGit(cmd *cobra.Command, defaults *cfg.Configuration) {
 }
 
 func listImages() error {
-	ns, err := kubernetes.Namespace()
+	namespace, err := kubernetes.Namespace()
 	if err != nil {
 		return err
 	}
-	imageStreams, err := openshift.ListImageStreams(ns)
+	imageStreams, err := openshift.ListImageStreams(namespace)
 	if err != nil {
 		return err
 	}
@@ -111,8 +111,8 @@ func listImages() error {
 		imageNames = append(imageNames, image.Name)
 	}
 	log.WithFields(log.Fields{
-		"\n - project":  ns,
-		"\n - 📺 images": imageNames,
+		"\n - namespace": namespace,
+		"\n - 📺 images":  imageNames,
 	}).Info("Please select an image. The following images are available:")
 	return nil
 }
@@ -131,7 +131,7 @@ func listConfigMaps(args []string) error {
 	configMapNames, labels := getNamesAndLabels(configMaps)
 
 	log.WithFields(log.Fields{
-		"\n - project":      namespace,
+		"\n - namespace":    namespace,
 		"\n - 🔓 configMaps": configMapNames,
 		"\n - 🎫 labels":     labels,
 	}).Info("Please use labels to select ConfigMaps. The following ConfigMaps and Labels are available:")
@@ -150,7 +150,7 @@ func listSecrets(args []string) error {
 
 	secretNames, labels := getNamesAndLabels(secrets)
 	log.WithFields(log.Fields{
-		"\n - project":   namespace,
+		"\n - namespace": namespace,
 		"\n - 🔐 secrets": secretNames,
 		"\n - 🎫 labels":  labels,
 	}).Info("Please use labels to select Secrets. The following Secrets and Labels are available:")

--- a/cmd/configmaps.go
+++ b/cmd/configmaps.go
@@ -92,7 +92,7 @@ func executeConfigMapCleanupCommand(args []string) error {
 				return client.ConfigMaps(namespace)
 			})
 	} else {
-		PrintResources(filteredConfigMaps)
+		PrintResources(filteredConfigMaps, namespace)
 	}
 
 	return nil

--- a/cmd/configmaps.go
+++ b/cmd/configmaps.go
@@ -42,7 +42,8 @@ func init() {
 	rootCmd.AddCommand(configMapCmd)
 	defaults := cfg.NewDefaultConfig()
 
-	configMapCmd.PersistentFlags().BoolP("force", "f", defaults.Force, "Confirm deletion of ConfigMaps.")
+	configMapCmd.PersistentFlags().BoolP("delete", "d", defaults.Delete, "Confirm deletion of ConfigMaps.")
+	configMapCmd.PersistentFlags().BoolP("force", "f", defaults.Delete, "(deprecated) Alias for --delete")
 	configMapCmd.PersistentFlags().StringSliceP("label", "l", defaults.Resource.Labels, "Identify the config map by these labels")
 	configMapCmd.PersistentFlags().IntP("keep", "k", defaults.History.Keep,
 		"Keep most current <k> ConfigMaps. Does not include currently used ConfigMaps (if detected).")
@@ -93,7 +94,7 @@ func executeConfigMapCleanupCommand(args []string) error {
 	PrintResources(filteredConfigMaps)
 	DeleteResources(
 		filteredConfigMaps,
-		config.Force,
+		config.Delete,
 		func(client *core.CoreV1Client) cfg.CoreObjectInterface {
 			return client.ConfigMaps(namespace)
 		})

--- a/cmd/configmaps.go
+++ b/cmd/configmaps.go
@@ -21,7 +21,7 @@ var configMapLog *log.Entry
 var (
 	// configMapCmd represents a cobra command to clean up unused ConfigMaps
 	configMapCmd = &cobra.Command{
-		Use:          "configmaps [PROJECT]",
+		Use:          "configmaps [NAMESPACE]",
 		Short:        "Cleans up your unused ConfigMaps in the Kubernetes cluster",
 		Long:         configMapCommandLongDescription,
 		Aliases:      []string{"configmap", "cm"},

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -95,7 +95,10 @@ func ExecuteHistoryCleanupCommand(args []string) error {
 		}).Info("No inactive image stream tags found")
 		return nil
 	}
-	PrintImageTags(inactiveTags)
-	DeleteImages(inactiveTags, image, namespace, config.Delete)
+	if config.Delete {
+		DeleteImages(inactiveTags, image, namespace)
+	} else {
+		PrintImageTags(inactiveTags)
+	}
 	return nil
 }

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -13,7 +13,7 @@ import (
 
 var (
 	historyCmd = &cobra.Command{
-		Use:          "history [PROJECT/IMAGE]",
+		Use:          "history [NAMESPACE/IMAGE]",
 		Aliases:      []string{"hist"},
 		Short:        "Clean up excessive image tags",
 		Long:         `Clean up excessive image tags matching the commit hashes (prefix) of the git repository`,
@@ -62,7 +62,7 @@ func ExecuteHistoryCleanupCommand(args []string) error {
 
 	imageStreamObjectTags, err := openshift.GetImageStreamTags(namespace, image)
 	if err != nil {
-		return fmt.Errorf("could not retrive image stream '%s/%s': %w", namespace, image, err)
+		return fmt.Errorf("could not retrieve image stream '%s/%s': %w", namespace, image, err)
 	}
 
 	var imageStreamTags []string

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -90,12 +90,12 @@ func ExecuteHistoryCleanupCommand(args []string) error {
 	inactiveTags = cleanup.LimitTags(&inactiveTags, c.Keep)
 	if len(inactiveTags) == 0 {
 		log.WithFields(log.Fields{
-			"namespace": namespace,
-			"imageName": image,
+			"\n - namespace": namespace,
+			"\n - imageName": image,
 		}).Info("No inactive image stream tags found")
 		return nil
 	}
 	PrintImageTags(inactiveTags)
-	DeleteImages(inactiveTags, image, namespace, config.Force)
+	DeleteImages(inactiveTags, image, namespace, config.Delete)
 	return nil
 }

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -58,11 +58,11 @@ func ExecuteHistoryCleanupCommand(args []string) error {
 		return listImages()
 	}
 	c := config.History
-	namespace, image, _ := splitNamespaceAndImagestream(args[0])
+	namespace, imageName, _ := splitNamespaceAndImagestream(args[0])
 
-	imageStreamObjectTags, err := openshift.GetImageStreamTags(namespace, image)
+	imageStreamObjectTags, err := openshift.GetImageStreamTags(namespace, imageName)
 	if err != nil {
-		return fmt.Errorf("could not retrieve image stream '%s/%s': %w", namespace, image, err)
+		return fmt.Errorf("could not retrieve image stream '%s/%s': %w", namespace, imageName, err)
 	}
 
 	var imageStreamTags []string
@@ -81,9 +81,9 @@ func ExecuteHistoryCleanupCommand(args []string) error {
 	}
 	var matchingTags = cleanup.GetMatchingTags(&gitCandidates, &imageStreamTags, matchOption)
 
-	activeImageStreamTags, err := openshift.GetActiveImageStreamTags(namespace, image, matchingTags)
+	activeImageStreamTags, err := openshift.GetActiveImageStreamTags(namespace, imageName, matchingTags)
 	if err != nil {
-		return fmt.Errorf("could not retrieve active image stream tags for '%s/%s': %w", namespace, image, err)
+		return fmt.Errorf("could not retrieve active image stream tags for '%s/%s': %w", namespace, imageName, err)
 	}
 
 	inactiveTags := cleanup.GetInactiveImageTags(&activeImageStreamTags, &matchingTags)
@@ -91,14 +91,14 @@ func ExecuteHistoryCleanupCommand(args []string) error {
 	if len(inactiveTags) == 0 {
 		log.WithFields(log.Fields{
 			"\n - namespace": namespace,
-			"\n - imageName": image,
+			"\n - 📺 image":   imageName,
 		}).Info("No inactive image stream tags found")
 		return nil
 	}
 	if config.Delete {
-		DeleteImages(inactiveTags, image, namespace)
+		DeleteImages(inactiveTags, imageName, namespace)
 	} else {
-		PrintImageTags(inactiveTags)
+		PrintImageTags(inactiveTags, imageName, namespace)
 	}
 	return nil
 }

--- a/cmd/images.go
+++ b/cmd/images.go
@@ -6,8 +6,9 @@ import (
 
 // imagesCmd represents the images command
 var imagesCmd = &cobra.Command{
-	Use:   "images",
-	Short: "Cleans up your image registry from unused image tags",
+	Use:     "images",
+	Short:   "Cleans up your image registry from unused image tags",
+	Aliases: []string{"image", "img"},
 }
 
 func init() {

--- a/cmd/orphans.go
+++ b/cmd/orphans.go
@@ -110,13 +110,13 @@ func ExecuteOrphanCleanupCommand(args []string) error {
 	}
 	if len(imageTagList) == 0 {
 		log.WithFields(log.Fields{
-			"namespace": namespace,
-			"imageName": imageName,
+			"\n - namespace": namespace,
+			"\n - imageName": imageName,
 		}).Info("No orphaned image stream tags found")
 		return nil
 	}
 	PrintImageTags(imageTagList)
-	DeleteImages(imageTagList, imageName, namespace, config.Force)
+	DeleteImages(imageTagList, imageName, namespace, config.Delete)
 	return nil
 }
 

--- a/cmd/orphans.go
+++ b/cmd/orphans.go
@@ -111,7 +111,7 @@ func ExecuteOrphanCleanupCommand(args []string) error {
 	if len(imageTagList) == 0 {
 		log.WithFields(log.Fields{
 			"\n - namespace": namespace,
-			"\n - imageName": imageName,
+			"\n - 📺 image":   imageName,
 		}).Info("No orphaned image stream tags found")
 		return nil
 	}
@@ -119,7 +119,7 @@ func ExecuteOrphanCleanupCommand(args []string) error {
 	if config.Delete {
 		DeleteImages(imageTagList, imageName, namespace)
 	} else {
-		PrintImageTags(imageTagList)
+		PrintImageTags(imageTagList, imageName, namespace)
 	}
 
 	return nil

--- a/cmd/orphans.go
+++ b/cmd/orphans.go
@@ -27,7 +27,7 @@ var (
 	// orphanCmd represents a cobra command to clean up images by comparing the git commit history. It removes any
 	// image tags that are not found in the git history by given criteria.
 	orphanCmd = &cobra.Command{
-		Use:          "orphans [PROJECT/IMAGE]",
+		Use:          "orphans [NAMESPACE/IMAGE]",
 		Short:        "Clean up unknown image tags",
 		Long:         orphanCommandLongDescription,
 		Aliases:      []string{"orph", "orphan"},

--- a/cmd/orphans_test.go
+++ b/cmd/orphans_test.go
@@ -37,7 +37,7 @@ func Test_splitNamespaceAndImagestream(t *testing.T) {
 		{
 			name: "ShouldThrowError_IfRepoIsInvalid",
 			args: args{
-				repo: "asdf",
+				repo: "/",
 			},
 			wantErr: true,
 		},
@@ -119,7 +119,7 @@ func Test_validateOrphanCommandInput(t *testing.T) {
 		{
 			name: "ShouldThrowError_IfInvalidImageRepository",
 			input: args{
-				args: []string{"invalid"},
+				args: []string{"/"},
 			},
 			wantErr: true,
 		},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,7 @@ func Execute() error {
 }
 
 func init() {
+	rootCmd.PersistentFlags().StringP("namespace", "n", config.Namespace, "Cluster namespace of current context")
 	rootCmd.PersistentFlags().String("log.level", config.Log.LogLevel, "Log level, one of [debug info warn error fatal]")
 	rootCmd.PersistentFlags().BoolP("log.verbose", "v", config.Log.Verbose, "Shorthand for --log.level debug")
 	rootCmd.PersistentFlags().BoolP("log.batch", "b", config.Log.Batch, "Use Batch mode (disables logging, prints deleted images only)")
@@ -66,6 +67,12 @@ func parseConfig(cmd *cobra.Command, args []string) {
 		log.SetLevel(log.InfoLevel)
 	} else {
 		log.SetLevel(level)
+	}
+
+	if config.Force {
+		log.Warn("--force is deprecated and will be removed by June 30, 2020. Please use --delete instead.")
+		log.Warn("Continuing with --delete")
+		config.Delete = true
 	}
 }
 

--- a/cmd/secrets.go
+++ b/cmd/secrets.go
@@ -89,7 +89,7 @@ func executeSecretCleanupCommand(args []string) error {
 				return client.Secrets(namespace)
 			})
 	} else {
-		PrintResources(filteredSecrets)
+		PrintResources(filteredSecrets, namespace)
 	}
 
 	return nil

--- a/cmd/secrets.go
+++ b/cmd/secrets.go
@@ -39,7 +39,8 @@ func init() {
 	rootCmd.AddCommand(secretCmd)
 	defaults := cfg.NewDefaultConfig()
 
-	secretCmd.PersistentFlags().BoolP("force", "f", defaults.Force, "Confirm deletion of secrets.")
+	secretCmd.PersistentFlags().BoolP("delete", "d", defaults.Delete, "Confirm deletion of secrets.")
+	secretCmd.PersistentFlags().BoolP("force", "f", defaults.Delete, "(deprecated) Alias for --delete")
 	secretCmd.PersistentFlags().StringSliceP("label", "l", defaults.Resource.Labels, "Identify the secret by these labels")
 	secretCmd.PersistentFlags().IntP("keep", "k", defaults.History.Keep,
 		"Keep most current <k> secrets. Does not include currently used secret (if detected).")
@@ -90,7 +91,7 @@ func executeSecretCleanupCommand(args []string) error {
 	PrintResources(filteredSecrets)
 	DeleteResources(
 		filteredSecrets,
-		config.Force,
+		config.Delete,
 		func(client *core.CoreV1Client) cfg.CoreObjectInterface {
 			return client.Secrets(namespace)
 		})

--- a/cmd/secrets.go
+++ b/cmd/secrets.go
@@ -19,7 +19,7 @@ This command deletes secrets that are not being used anymore.`
 var (
 	// secretCmd represents a cobra command to clean up unused secrets
 	secretCmd = &cobra.Command{
-		Use:          "secrets [PROJECT]",
+		Use:          "secrets [NAMESPACE]",
 		Short:        "Cleans up your unused secrets in the Kubernetes cluster",
 		Long:         secretCommandLongDescription,
 		Aliases:      []string{"secret"},

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/etdub/goparsetime v0.0.0-20160315173935-ea17b0ac3318 // indirect
+	github.com/go-delve/delve v1.4.0 // indirect
 	github.com/hashicorp/go-version v1.2.0
 	github.com/heroku/docker-registry-client v0.0.0-20190909225348-afc9e1acc3d5
 	github.com/imdario/mergo v0.3.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cosiner/argv v0.0.0-20170225145430-13bacc38a0a5/go.mod h1:p/NrK5tF6ICIly4qwEDsf6VDirFiWWz0FenfYBwJaKQ=
+github.com/cpuguy83/go-md2man v1.0.8/go.mod h1:N6JayAiVKtlHSnuTCeuLSQVs75hb8q+dYQLjr7cDsKY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -47,6 +49,8 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-critic/go-critic v0.3.5-0.20190526074819-1df300866540/go.mod h1:+sE8vrLDS2M0pZkBk0wy6+nLdKexVDrl/jBqQOTDThA=
+github.com/go-delve/delve v1.4.0 h1:O+1dw1XBZXqhC6fIPQwGxLlbd2wDRau7NxNhVpw02ag=
+github.com/go-delve/delve v1.4.0/go.mod h1:gQM0ReOJLNAvPuKAXfjHngtE93C2yc/ekTbo7YbAHSo=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-lintpack/lintpack v0.5.2/go.mod h1:NwZuYi2nUHho8XEIZ6SIxihrnPoqBTDqfpXvXAN0sXM=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
@@ -164,6 +168,7 @@ github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDe
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/mattn/go-colorable v0.0.0-20170327083344-ded68f7a9561/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
@@ -188,8 +193,10 @@ github.com/nbutton23/zxcvbn-go v0.0.0-20171102151520-eafdab6b0663/go.mod h1:o96d
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.2/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/openshift/api v3.9.1-0.20190322043348-8741ff068a47+incompatible h1:p0ypM7AY7k2VY6ILDPbg3LajGA97hFUt2DGVEQz2Yd4=
@@ -201,10 +208,12 @@ github.com/pelletier/go-toml v1.1.0 h1:cmiOvKzEunMsAxyhXSzpL5Q1CRKpVv0KQsnAIcSEV
 github.com/pelletier/go-toml v1.1.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/peterh/liner v0.0.0-20170317030525-88609521dc4b/go.mod h1:xIteQHvHuaLYG9IFj6mSxM0fCKrs34IrEQUhOYuGPHc=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/profile v0.0.0-20170413231811-06b906832ed0/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -219,6 +228,7 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/russross/blackfriday v0.0.0-20180428102519-11635eb403ff/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/go-glob v0.0.0-20170128012129-256dc444b735/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
@@ -228,6 +238,7 @@ github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/sirupsen/logrus v0.0.0-20180523074243-ea8897e79973/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.0.5/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
@@ -247,6 +258,7 @@ github.com/spf13/cast v1.2.0 h1:HHl1DSRbEQN2i8tJmtS6ViPyHx35+p51amrdsiTCrkg=
 github.com/spf13/cast v1.2.0/go.mod h1:r2rcYCSwa1IExKTDiTfzaxqT2FNHs8hODu4LnUfgKEg=
 github.com/spf13/cast v1.3.0 h1:oget//CVOEoFewqQxwr0Ej5yjygnqGkvggSE/gB35Q8=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cobra v0.0.0-20170417170307-b6cb39589372/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.2 h1:NfkwRbgViGoyjBKsLI0QMDcuMnhM+SBg3T0cGfpvKDE=
 github.com/spf13/cobra v0.0.2/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.6 h1:breEStsVwemnKh2/s6gMvSdMEkwW0sK8vGStnlVBMCs=
@@ -255,6 +267,7 @@ github.com/spf13/jwalterweatherman v0.0.0-20180109140146-7c0cea34c8ec h1:2ZXvIUG
 github.com/spf13/jwalterweatherman v0.0.0-20180109140146-7c0cea34c8ec/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.0.0 h1:XHEdyB+EcvlqZamSM4ZOMGlc93t6AcsBEu9Gc1vn7yk=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
+github.com/spf13/pflag v0.0.0-20170417173400-9e4c21054fa1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1 h1:aCvUg6QPl3ibpQUxyLkrEkCHtPqYJL4x9AuhqVqFis4=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
@@ -296,9 +309,11 @@ github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0B
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
+go.starlark.net v0.0.0-20190702223751-32f345186213/go.mod h1:c1/X6cHgvdXj6pUlmWKMkuqRnW4K8x2vwt6JAaaircg=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
+golang.org/x/arch v0.0.0-20190927153633-4e8777c89be4/go.mod h1:flIaEI6LNU6xOCD5PaJvn9wGP0agmIOqjrtsKGRguv4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -342,6 +357,7 @@ golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e h1:D5TXcfTk7xF7hvieo4QErS3qqCB4teTffacDWr7CI+0=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191018095205-727590c5006e h1:ZtoklVMHQy6BFRHkbG6JzK+S6rX82//Yeok1vMlizfQ=
@@ -369,6 +385,8 @@ golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190521203540-521d6ed310dd/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190729092621-ff9f1409240a h1:mEQZbbaBjWyLNy0tmZmgEuQAR8XOQ3hL8GYi3J/NG64=
 golang.org/x/tools v0.0.0-20190729092621-ff9f1409240a/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
+golang.org/x/tools v0.0.0-20191127201027-ecd32218bd7f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
@@ -414,4 +432,5 @@ k8s.io/client-go v11.0.0+incompatible h1:LBbX2+lOwY9flffWlJM7f1Ct8V2SRNiMRDFeiwn
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
 mvdan.cc/unparam v0.0.0-20190209190245-fbb59629db34/go.mod h1:H6SUd1XjIs+qQCyskXg5OFSrilMRUkD8ePJpHKDPaeY=
+rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 sourcegraph.com/sqs/pbtypes v0.0.0-20180604144634-d3ebe8f20ae4/go.mod h1:ketZ/q3QxT9HOBeFhu6RdvsftgpsbFHBF5Cas6cDKZ0=


### PR DESCRIPTION
* Makes conversation with users more friendly on the command line
* Makes specifying namespace optional for cleaning up images, adds `-n` option
* Adds *dist* target to `Makefile` to build all target binaries locally
* Updates development instructions (`make` commands) in README
* Updates migration instructions for `oc` cleanup plugin users (README)