### PR TITLE
Change defaults (--keep, --older-than) and explain

### DIFF
--- a/cfg/types.go
+++ b/cfg/types.go
@@ -67,15 +67,15 @@ func NewDefaultConfig() *Configuration {
 			SortCriteria: "version",
 		},
 		History: HistoryConfig{
-			Keep: 10,
+			Keep: 3,
 		},
 		Orphan: OrphanConfig{
-			OlderThan:           "2mo",
+			OlderThan:           "1w",
 			OrphanDeletionRegex: "^[a-z0-9]{40}$",
 		},
 		Resource: ResourceConfig{
 			Labels:    []string{},
-			OlderThan: "2mo",
+			OlderThan: "1w",
 		},
 		Delete: false,
 		Force:  false,

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -74,7 +74,7 @@ func PrintResources(resources []cfg.KubernetesResource, namespace string) {
 // addCommonFlagsForGit sets up the delete flag, as well as the common git flags. Adding the flags to the root cmd would make those
 // global, even for commands that do not need them, which might be overkill.
 func addCommonFlagsForGit(cmd *cobra.Command, defaults *cfg.Configuration) {
-	cmd.PersistentFlags().BoolP("delete", "d", defaults.Delete, "Confirm deletion of image tags.")
+	cmd.PersistentFlags().BoolP("delete", "d", defaults.Delete, "Effectively delete image tags found")
 	cmd.PersistentFlags().BoolP("force", "f", defaults.Delete, "(deprecated) Alias for --delete")
 	cmd.PersistentFlags().IntP("commit-limit", "l", defaults.Git.CommitLimit,
 		"Only look at the first <l> commits to compare with tags. Use 0 (zero) for all commits. Limited effect if repo is a shallow clone.")

--- a/cmd/configmaps.go
+++ b/cmd/configmaps.go
@@ -42,12 +42,12 @@ func init() {
 	rootCmd.AddCommand(configMapCmd)
 	defaults := cfg.NewDefaultConfig()
 
-	configMapCmd.PersistentFlags().BoolP("delete", "d", defaults.Delete, "Confirm deletion of ConfigMaps.")
-	configMapCmd.PersistentFlags().StringSliceP("label", "l", defaults.Resource.Labels, "Identify the config map by these labels")
+	configMapCmd.PersistentFlags().BoolP("delete", "d", defaults.Delete, "Effectively delete ConfigMaps found")
+	configMapCmd.PersistentFlags().StringSliceP("label", "l", defaults.Resource.Labels, "Identify the ConfigMap by these labels")
 	configMapCmd.PersistentFlags().IntP("keep", "k", defaults.History.Keep,
-		"Keep most current <k> ConfigMaps. Does not include currently used ConfigMaps (if detected).")
+		"Keep most current <k> ConfigMaps; does not include currently used ConfigMaps (if detected)")
 	configMapCmd.PersistentFlags().String("older-than", defaults.Resource.OlderThan,
-		"Delete ConfigMaps that are older than the duration. Ex.: [1y2mo3w4d5h6m7s]")
+		"Delete ConfigMaps that are older than the duration, e.g. [1y2mo3w4d5h6m7s]")
 }
 
 func validateConfigMapCommandInput(args []string) error {
@@ -92,6 +92,7 @@ func executeConfigMapCleanupCommand(args []string) error {
 				return client.ConfigMaps(namespace)
 			})
 	} else {
+		log.Infof("Showing results for --keep=%d and --older-than=%s", config.History.Keep, c.OlderThan)
 		PrintResources(filteredConfigMaps, namespace)
 	}
 

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -98,6 +98,7 @@ func ExecuteHistoryCleanupCommand(args []string) error {
 	if config.Delete {
 		DeleteImages(inactiveTags, imageName, namespace)
 	} else {
+		log.Infof("Showing results for --commit-limit=%d and --keep=%d", config.Git.CommitLimit, c.Keep)
 		PrintImageTags(inactiveTags, imageName, namespace)
 	}
 	return nil

--- a/cmd/orphans.go
+++ b/cmd/orphans.go
@@ -58,15 +58,15 @@ func validateOrphanCommandInput(args []string) error {
 	if len(args) == 0 {
 		return nil
 	}
-	o := config.Orphan
+	c := config.Orphan
 	if _, _, err := splitNamespaceAndImagestream(args[0]); err != nil {
 		return err
 	}
-	if _, err := parseOrphanDeletionRegex(o.OrphanDeletionRegex); err != nil {
+	if _, err := parseOrphanDeletionRegex(c.OrphanDeletionRegex); err != nil {
 		return fmt.Errorf("could not parse orphan deletion pattern: %w", err)
 	}
 
-	if _, err := parseCutOffDateTime(o.OlderThan); err != nil {
+	if _, err := parseCutOffDateTime(c.OlderThan); err != nil {
 		return fmt.Errorf("could not parse older-than flag: %w", err)
 	}
 
@@ -81,7 +81,7 @@ func ExecuteOrphanCleanupCommand(args []string) error {
 	if len(args) == 0 {
 		return listImages()
 	}
-	o := config.Orphan
+	c := config.Orphan
 	namespace, imageName, _ := splitNamespaceAndImagestream(args[0])
 
 	allImageTags, err := openshift.GetImageStreamTags(namespace, imageName)
@@ -89,8 +89,8 @@ func ExecuteOrphanCleanupCommand(args []string) error {
 		return fmt.Errorf("could not retrieve image stream '%v/%v': %w", namespace, imageName, err)
 	}
 
-	cutOffDateTime, _ := parseCutOffDateTime(o.OlderThan)
-	orphanIncludeRegex, _ := parseOrphanDeletionRegex(o.OrphanDeletionRegex)
+	cutOffDateTime, _ := parseCutOffDateTime(c.OlderThan)
+	orphanIncludeRegex, _ := parseOrphanDeletionRegex(c.OrphanDeletionRegex)
 
 	matchOption := cleanup.MatchOptionPrefix
 	if config.Git.Tag {
@@ -119,6 +119,7 @@ func ExecuteOrphanCleanupCommand(args []string) error {
 	if config.Delete {
 		DeleteImages(imageTagList, imageName, namespace)
 	} else {
+		log.Infof("Showing results for --commit-limit=%d and --older-than=%s", config.Git.CommitLimit, c.OlderThan)
 		PrintImageTags(imageTagList, imageName, namespace)
 	}
 

--- a/cmd/orphans_test.go
+++ b/cmd/orphans_test.go
@@ -28,6 +28,14 @@ func Test_splitNamespaceAndImagestream(t *testing.T) {
 			expectedImage:     "image",
 		},
 		{
+			name: "ShouldReturnActiveNamespace_IfRepoDoesNotContainNamespace",
+			args: args{
+				repo: "image",
+			},
+			expectedNamespace: "currently-active-ns",
+			expectedImage:     "image",
+		},
+		{
 			name: "ShouldThrowError_IfRepoDoesNotContainImage",
 			args: args{
 				repo: "namespace/",
@@ -57,6 +65,7 @@ func Test_splitNamespaceAndImagestream(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			config.Namespace = "currently-active-ns"
 			namespace, image, err := splitNamespaceAndImagestream(tt.args.repo)
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/cmd/secrets.go
+++ b/cmd/secrets.go
@@ -39,12 +39,12 @@ func init() {
 	rootCmd.AddCommand(secretCmd)
 	defaults := cfg.NewDefaultConfig()
 
-	secretCmd.PersistentFlags().BoolP("delete", "d", defaults.Delete, "Confirm deletion of secrets.")
-	secretCmd.PersistentFlags().StringSliceP("label", "l", defaults.Resource.Labels, "Identify the secret by these labels")
+	secretCmd.PersistentFlags().BoolP("delete", "d", defaults.Delete, "Effectively delete Secrets found")
+	secretCmd.PersistentFlags().StringSliceP("label", "l", defaults.Resource.Labels, "Identify the Secret by these labels")
 	secretCmd.PersistentFlags().IntP("keep", "k", defaults.History.Keep,
-		"Keep most current <k> secrets. Does not include currently used secret (if detected).")
+		"Keep most current <k> Secrets; does not include currently used secret (if detected)")
 	secretCmd.PersistentFlags().String("older-than", defaults.Resource.OlderThan,
-		"Delete secrets that are older than the duration. Ex.: [1y2mo3w4d5h6m7s]")
+		"Delete Secrets that are older than the duration, e.g. [1y2mo3w4d5h6m7s]")
 }
 
 func validateSecretCommandInput(args []string) error {
@@ -89,6 +89,7 @@ func executeSecretCleanupCommand(args []string) error {
 				return client.Secrets(namespace)
 			})
 	} else {
+		log.Infof("Showing results for --keep=%d and --older-than=%s", config.History.Keep, c.OlderThan)
 		PrintResources(filteredSecrets, namespace)
 	}
 


### PR DESCRIPTION
* Changes the defaults for the `--keep` and `--older-than` CLI options.
* Explains the (default) values that are active when displaying results, which should make it easier to spot why in some cases there are unexpectedly few or many results.
* Changes and aligns styling and wording on help screens.
* Fixes tests for the orphans command by "mocking" the default Namespace.

Resolves: #22

## Side Note: Next Release

After this PR is merged we should probably go about publishing a new release (and package it with the [container-oc image](https://github.com/appuio/container-oc)). The [latest release](https://github.com/appuio/seiso/releases) is more than a month ago, and there have been significant advancements in the meantime. :rocket: 