### PR TITLE
Move logic out of the Configuration container

### DIFF
--- a/cfg/types.go
+++ b/cfg/types.go
@@ -1,10 +1,5 @@
 package cfg
 
-import (
-	"github.com/appuio/seiso/pkg/kubernetes"
-	log "github.com/sirupsen/logrus"
-)
-
 type (
 	// Configuration holds a strongly-typed tree of the configuration
 	Configuration struct {
@@ -47,13 +42,7 @@ type (
 
 // NewDefaultConfig retrieves the hardcoded configs with sane defaults
 func NewDefaultConfig() *Configuration {
-	namespace, err := kubernetes.Namespace()
-	if err != nil {
-		log.Warning("Unable to determine default namespace. Falling back to: default")
-		namespace = "default"
-	}
 	return &Configuration{
-		Namespace: namespace,
 		Git: GitConfig{
 			CommitLimit:  0,
 			RepoPath:     ".",

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -58,6 +58,12 @@ func toListOptions(labels []string) metav1.ListOptions {
 	}
 }
 
+func showUsageOnError(cmd *cobra.Command, err error) {
+	if err != nil {
+		cmd.Usage()
+	}
+}
+
 func missingLabelSelectorError(namespace, resource string) error {
 	return fmt.Errorf("label selector with --label expected. You can print out available labels with \"kubectl -n %s get %s --show-labels\"", namespace, resource)
 }

--- a/cmd/configmaps.go
+++ b/cmd/configmaps.go
@@ -7,6 +7,7 @@ import (
 	"github.com/appuio/seiso/pkg/kubernetes"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"strings"
 )
 
 const (
@@ -22,24 +23,8 @@ var (
 		Aliases:      []string{"configmap", "cm"},
 		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			log.SetFormatter(&log.TextFormatter{DisableTimestamp: true})
-			if err := validateConfigMapCommandInput(); err != nil {
-				cmd.Usage()
-				return err
-			}
-
-			coreClient, err := kubernetes.NewCoreV1Client()
-			if err != nil {
-				return fmt.Errorf("cannot initiate kubernetes core client")
-			}
-
-			configMapService := configmap.NewConfigMapsService(
-				coreClient.ConfigMaps(config.Namespace),
-				kubernetes.New(),
-				configmap.ServiceConfiguration{Batch: config.Log.Batch})
-			return executeConfigMapCleanupCommand(configMapService)
-		},
+		PreRunE:      validateConfigMapCommandInput,
+		RunE:         executeConfigMapCleanupCommand,
 	}
 )
 
@@ -48,16 +33,23 @@ func init() {
 	defaults := cfg.NewDefaultConfig()
 
 	configMapCmd.PersistentFlags().BoolP("delete", "d", defaults.Delete, "Effectively delete ConfigMaps found")
-	configMapCmd.PersistentFlags().StringSliceP("label", "l", defaults.Resource.Labels, "Identify the ConfigMap by these labels")
+	configMapCmd.PersistentFlags().StringSliceP("label", "l", defaults.Resource.Labels,
+		"Identify the ConfigMap by these \"key=value\" labels")
 	configMapCmd.PersistentFlags().IntP("keep", "k", defaults.History.Keep,
 		"Keep most current <k> ConfigMaps; does not include currently used ConfigMaps (if detected)")
 	configMapCmd.PersistentFlags().String("older-than", defaults.Resource.OlderThan,
 		"Delete ConfigMaps that are older than the duration, e.g. [1y2mo3w4d5h6m7s]")
 }
 
-func validateConfigMapCommandInput() error {
+func validateConfigMapCommandInput(cmd *cobra.Command, args []string) (returnErr error) {
+	defer showUsageOnError(cmd, returnErr)
 	if len(config.Resource.Labels) == 0 {
 		return missingLabelSelectorError(config.Namespace, "configmaps")
+	}
+	for _, label := range config.Resource.Labels {
+		if !strings.Contains(label, "=") {
+			return fmt.Errorf("incorrect label format does not match expected \"key=value\" format: %s", label)
+		}
 	}
 	if _, err := parseCutOffDateTime(config.Resource.OlderThan); err != nil {
 		return fmt.Errorf("could not parse older-than flag: %w", err)
@@ -65,9 +57,18 @@ func validateConfigMapCommandInput() error {
 	return nil
 }
 
-func executeConfigMapCleanupCommand(service configmap.Service) error {
+func executeConfigMapCleanupCommand(cmd *cobra.Command, args []string) error {
+	coreClient, err := kubernetes.NewCoreV1Client()
+	if err != nil {
+		return fmt.Errorf("cannot initiate kubernetes client: %w", err)
+	}
+
 	c := config.Resource
 	namespace := config.Namespace
+	service := configmap.NewConfigMapsService(
+		coreClient.ConfigMaps(namespace),
+		kubernetes.New(),
+		configmap.ServiceConfiguration{Batch: config.Log.Batch})
 
 	log.WithField("namespace", namespace).Debug("Getting ConfigMaps")
 	foundConfigMaps, err := service.List(toListOptions(c.Labels))

--- a/cmd/images.go
+++ b/cmd/images.go
@@ -24,10 +24,10 @@ func splitNamespaceAndImagestream(repo string) (namespace string, image string, 
 	} else {
 		paths := strings.SplitAfter(repo, "/")
 		if len(paths) >= 3 {
-			namespace = paths[1]
+			namespace = strings.TrimSuffix(paths[1], "/")
 			image = paths[2]
 		} else {
-			namespace = paths[0]
+			namespace = strings.TrimSuffix(paths[0], "/")
 			image = paths[1]
 		}
 	}
@@ -37,5 +37,5 @@ func splitNamespaceAndImagestream(repo string) (namespace string, image string, 
 	if image == "" {
 		return "", "", errors.New("missing or invalid image name")
 	}
-	return strings.TrimSuffix(namespace, "/"), image, nil
+	return namespace, image, nil
 }

--- a/cmd/images_test.go
+++ b/cmd/images_test.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_SplitNamespaceAndImagestream(t *testing.T) {
+	type args struct {
+		repo string
+	}
+	tests := []struct {
+		name              string
+		args              args
+		expectedNamespace string
+		expectedImage     string
+		wantErr           bool
+	}{
+		{
+			name: "ShouldSplit_NamespaceAndImageName",
+			args: args{
+				repo: "namespace/image",
+			},
+			expectedNamespace: "namespace",
+			expectedImage:     "image",
+		},
+		{
+			name: "ShouldReturnActiveNamespace_IfRepoDoesNotContainNamespace",
+			args: args{
+				repo: "image",
+			},
+			expectedNamespace: "currently-active-ns",
+			expectedImage:     "image",
+		},
+		{
+			name: "ShouldThrowError_IfRepoDoesNotContainImage",
+			args: args{
+				repo: "namespace/",
+			},
+			wantErr: true,
+		},
+		{
+			name: "ShouldThrowError_IfRepoIsInvalid",
+			args: args{
+				repo: "/",
+			},
+			wantErr: true,
+		},
+		{
+			name:    "ShouldThrowError_IfRepoIsEmpty",
+			args:    args{},
+			wantErr: true,
+		},
+		{
+			name: "ShouldIgnore_Registry",
+			args: args{
+				repo: "docker.io/namespace/image",
+			},
+			expectedNamespace: "namespace",
+			expectedImage:     "image",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config.Namespace = "currently-active-ns"
+			namespace, image, err := splitNamespaceAndImagestream(tt.args.repo)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, namespace, tt.expectedNamespace)
+			assert.Equal(t, image, tt.expectedImage)
+		})
+	}
+}

--- a/cmd/orphans_test.go
+++ b/cmd/orphans_test.go
@@ -1,82 +1,13 @@
 package cmd
 
 import (
+	"github.com/spf13/cobra"
 	"regexp"
 	"testing"
 
 	"github.com/appuio/seiso/cfg"
 	"github.com/stretchr/testify/assert"
 )
-
-func Test_splitNamespaceAndImagestream(t *testing.T) {
-	type args struct {
-		repo string
-	}
-	tests := []struct {
-		name              string
-		args              args
-		expectedNamespace string
-		expectedImage     string
-		wantErr           bool
-	}{
-		{
-			name: "ShouldSplit_NamespaceAndImageName",
-			args: args{
-				repo: "namespace/image",
-			},
-			expectedNamespace: "namespace",
-			expectedImage:     "image",
-		},
-		{
-			name: "ShouldReturnActiveNamespace_IfRepoDoesNotContainNamespace",
-			args: args{
-				repo: "image",
-			},
-			expectedNamespace: "currently-active-ns",
-			expectedImage:     "image",
-		},
-		{
-			name: "ShouldThrowError_IfRepoDoesNotContainImage",
-			args: args{
-				repo: "namespace/",
-			},
-			wantErr: true,
-		},
-		{
-			name: "ShouldThrowError_IfRepoIsInvalid",
-			args: args{
-				repo: "/",
-			},
-			wantErr: true,
-		},
-		{
-			name:    "ShouldThrowError_IfRepoIsEmpty",
-			args:    args{},
-			wantErr: true,
-		},
-		{
-			name: "ShouldIgnore_Registry",
-			args: args{
-				repo: "docker.io/namespace/image",
-			},
-			expectedNamespace: "namespace",
-			expectedImage:     "image",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			config.Namespace = "currently-active-ns"
-			namespace, image, err := splitNamespaceAndImagestream(tt.args.repo)
-			if tt.wantErr {
-				assert.Error(t, err)
-				return
-			}
-			assert.NoError(t, err)
-			assert.Equal(t, namespace, tt.expectedNamespace)
-			assert.Equal(t, image, tt.expectedImage)
-		})
-	}
-}
 
 func Test_parseOrphanDeletionRegex(t *testing.T) {
 	type args struct {
@@ -173,7 +104,7 @@ func Test_validateOrphanCommandInput(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config = &tt.input.config
-			err := validateOrphanCommandInput(tt.input.args)
+			err := validateOrphanCommandInput(&cobra.Command{}, tt.input.args)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return


### PR DESCRIPTION
It shouldn't be necessary to figure out the namespace from kubeconfig if we just pass --version flag

Other changes:
- We only want -n flag and the ns/image args to be used to specify the namespace, to support future registries that don't rely on kubeconfig's configured namespace
- The default namespace is not used as a fallback anymore

Closes: #33 