### PR TITLE
Fix helper resource contains

### DIFF
--- a/pkg/kubernetes/util.go
+++ b/pkg/kubernetes/util.go
@@ -36,7 +36,9 @@ func (k *kubernetesImpl) ResourceContains(namespace, value string, resource sche
 		return false, err
 	}
 	for _, item := range objectlist.Items {
-		return ObjectContains(item.Object, value), nil
+		if ObjectContains(item.Object, value) {
+			return true, nil
+		}
 	}
 
 	return false, nil

--- a/pkg/openshift/resources.go
+++ b/pkg/openshift/resources.go
@@ -48,6 +48,7 @@ func GetActiveImageStreamTags(namespace, imageStream string, imageStreamTags []s
 
 			if contains {
 				activeImageStreamTags = append(activeImageStreamTags, imageStreamTag)
+				log.Infof("Found active image stream tag: %s/%s:%s", namespace, imageStream, imageStreamTag)
 			}
 		})
 	})


### PR DESCRIPTION
Hello,

I was looking why the command `seiso image history namespace/project --keep 0` wanted to remove our image stream which were running on our integration environment:

```$ seiso image history namespace/project --keep 0
INFO Seiso unknown, commit dirty, date today      
INFO Showing results for --commit-limit=0 and --keep=0 
INFO Found image tag candidate: namespace/project:cd3b3c7644b7ab1c1521d9b9d4c518543b5a51e7 
INFO Found image tag candidate: namespace/project:173d28aaf9d2cff8fa469ad1d0c6937326f88d74 
INFO Found image tag candidate: namespace/project:66ada63440a483c6e763bf9b26e4f1cc2e028834
```

The `cd3b3c7644b7ab1c1521d9b9d4c518543b5a51e7` tag is currently running so I was surprised it was a delete candidate.

I had to add a log.info to explicitly shows which tags were found active.

With this, log, I've found that  `cd3b3c7644b7ab1c1521d9b9d4c518543b5a51e7` tag wasn't found as active.

Then, I continue to debug and found this error in the `helper.ResourceContains`: it looked only one resource, didn't find the image tag and return.

This PRs fixes it to loop over all Resources up to find one matching.

The final result in my case is:

```
seiso image history namespace/project --keep 0
INFO Seiso unknown, commit dirty, date today      
INFO Found active image stream tag: namespace/project:725fe0e277a9055504c32f2d56e3aa2bfb9ab62b 
INFO Found active image stream tag: namespace/project:cd3b3c7644b7ab1c1521d9b9d4c518543b5a51e7 
INFO Found active image stream tag: namespace/project:173d28aaf9d2cff8fa469ad1d0c6937326f88d74 
INFO Found active image stream tag: namespace/project:66ada63440a483c6e763bf9b26e4f1cc2e028834 
INFO No inactive image stream tags found           
 - namespace=logi-winbiz 
 - 📺 image=backend
```

Unfortunately, I don't know Go and so I'm not be able to add / fix the unit tests.

