### PR TITLE
kubernetes/util: fix ResourceContains method and add unit test

### DIFF
--- a/pkg/kubernetes/util.go
+++ b/pkg/kubernetes/util.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/client-go/dynamic"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -35,11 +36,8 @@ func (k *kubernetesImpl) ResourceContains(namespace, value string, resource sche
 	if err != nil {
 		return false, err
 	}
-	for _, item := range objectlist.Items {
-		return ObjectContains(item.Object, value), nil
-	}
 
-	return false, nil
+	return UnstructuredListContains(objectlist, value), nil
 }
 
 func (k *kubernetesImpl) initClient() error {
@@ -83,4 +81,13 @@ func ObjectContains(genericObject interface{}, value string) bool {
 	default:
 		return false
 	}
+}
+
+func UnstructuredListContains(unstructuredList *unstructured.UnstructuredList, value string) bool {
+	for _, item := range unstructuredList.Items {
+		if ObjectContains(item.Object, value) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/kubernetes/util_test.go
+++ b/pkg/kubernetes/util_test.go
@@ -4,44 +4,125 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-type ObjectContainsTestCase struct {
-	object   interface{}
-	value    string
-	expected bool
+type UnstructuredListContainsTestCase struct {
+	objectlist *unstructured.UnstructuredList
+	value      string
+	expected   bool
 }
 
-func Test_ObjectContains(t *testing.T) {
-	testcases := []ObjectContainsTestCase{
+func Test_UnstructuredListContains(t *testing.T) {
+	testcases := []UnstructuredListContainsTestCase{
+		// Successful lookup string in map[string]interface{}
 		{
-			object:   map[string]interface{}{"int": 20, "bool": true, "string": "foo"},
-			value:    "foo",
-			expected: true,
-		},
-		{
-			object:   map[string]interface{}{"int": 20, "bool": true, "string": "foo"},
-			value:    "bar",
-			expected: false,
-		},
-		{
-			object: map[string]interface{}{
-				"apiVersion": "v1",
-				"kind":       "Pod",
-				"metadata":   map[string]interface{}{"name": "seiso", "namespace": "seiso-test"},
-				"spec": map[string]interface{}{
-					"containers": []interface{}{map[string]interface{}{
-						"serviceAccount": "default",
-						"image":          "docker.io/appuio/oc:0b81a958f590ed7ed8be6ec0a2a87816228a482c",
+			objectlist: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{"kind": "List", "apiVersion": "v1"},
+				Items: []unstructured.Unstructured{
+					{Object: map[string]interface{}{
+						"kind":       "Pod",
+						"apiVersion": "v1",
+						"metadata": map[string]interface{}{
+							"int":  20,
+							"bool": true,
+							"[]interface": []interface{}{map[string]interface{}{
+								"serviceAccount": "bar",
+								"name":           "bar",
+							}},
+							"name": "foo",
+						},
 					}},
 				},
 			},
-			value:    "oc:0b81a958f590ed7ed8be6ec0a2a87816228a482c",
+			value:    "foo",
+			expected: true,
+		},
+		// Successful lookup string in []interface{}
+		{
+			objectlist: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{"kind": "List", "apiVersion": "v1"},
+				Items: []unstructured.Unstructured{
+					{Object: map[string]interface{}{
+						"kind":       "Pod",
+						"apiVersion": "v1",
+						"metadata": map[string]interface{}{
+							"int":  20,
+							"bool": true,
+							"[]interface": []interface{}{map[string]interface{}{
+								"serviceAccount": "foo",
+								"name":           "bar",
+							}},
+							"name": "foo",
+						},
+					}},
+				},
+			},
+			value:    "bar",
+			expected: true,
+		},
+		// Lookup for non-existing value
+		{
+			objectlist: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{"kind": "List", "apiVersion": "v1"},
+				Items: []unstructured.Unstructured{
+					{Object: map[string]interface{}{
+						"kind":       "Pod",
+						"apiVersion": "v1",
+						"metadata": map[string]interface{}{
+							"int":  20,
+							"bool": true,
+							"[]interface": []interface{}{map[string]interface{}{
+								"serviceAccount": "foo",
+								"name":           "foo",
+							}},
+							"name": "foo",
+						},
+					}},
+				},
+			},
+			value:    "bar",
+			expected: false,
+		},
+		// Successful lookup for value in second element
+		{
+			objectlist: &unstructured.UnstructuredList{
+				Object: map[string]interface{}{"kind": "List", "apiVersion": "v1"},
+				Items: []unstructured.Unstructured{
+					{Object: map[string]interface{}{
+						"kind":       "Pod",
+						"apiVersion": "v1",
+						"metadata": map[string]interface{}{
+							"int":  20,
+							"bool": true,
+							"[]interface": []interface{}{map[string]interface{}{
+								"serviceAccount": "foo",
+								"name":           "foo",
+							}},
+							"name": "foo",
+						},
+					}},
+					{Object: map[string]interface{}{
+						"kind":       "Pod",
+						"apiVersion": "v1",
+						"metadata": map[string]interface{}{
+							"int":  20,
+							"bool": true,
+							"[]interface": []interface{}{map[string]interface{}{
+								"serviceAccount": "foo",
+								"name":           "foo",
+							}},
+							"name": "bar",
+						},
+					}},
+				},
+			},
+			value:    "bar",
 			expected: true,
 		},
 	}
 
 	for _, testcase := range testcases {
-		assert.Equal(t, testcase.expected, ObjectContains(testcase.object, testcase.value))
+		assert.Equal(t, testcase.expected, UnstructuredListContains(testcase.objectlist, testcase.value))
 	}
 }


### PR DESCRIPTION
Hello,

The idea of this PR is the same I proposed in #46, but with the addition of unit testing the value lookup of the original `ResourceContains` method.

First, I wanted to unit test directly the `ResourceContains` method, but I wasn't able to correctly create mocks for the `clientInit()` method and the `k.client.Resource(resource).Namespace(namespace).List(metav1.ListOptions{})` call.

Then, I found it was simpler to split the list lookup from ResourceContains method and unit test it directly. I think that's a good enough way to unit test ResourceContains algorithm, because the same way was used for the `ObjectContains()` method.

The first commit of this PR creates the method `UnstructuredListContains` with original code from `ResourceContains` and add unit tests for it. So, you can confirm with this commit alone the unit test is not passing actually if the value looked for is contained in the second element.

The second commit apply the fix from #46 and it fix correctly the unit test.

I didn't had back the logging line from #46 saying which active image stream was found. If you think it's interesting to add it, I can add a third commit to this PR.